### PR TITLE
overloaded AddContentTags()

### DIFF
--- a/CMSforce/src/main/java/com/revature/services/ContentService.java
+++ b/CMSforce/src/main/java/com/revature/services/ContentService.java
@@ -16,6 +16,8 @@ public interface ContentService {
 	
 	public boolean addContentTags(String[] subject);
 	
+	public boolean addContentTags(Module[] modules);
+	
 	public boolean removeContentTags(String[] subject);
 	
 	public boolean deleteContent(int id);


### PR DESCRIPTION
overloaded AddContentTags() to enable adding an array of modules.