### PR TITLE
Small one-line Dockerfile change, thought this was already taken care of

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,5 +1,5 @@
 FROM postgres:10
 ENV POSTGRES_USER projectthree
 ENV POSTGRES_PASSWORD password
-ADD CMSForceSQL.sql /docker-entrypoint-initdb.c
+ADD CMSForceSQL.sql /docker-entrypoint-initdb.d/
 EXPOSE 5432


### PR DESCRIPTION
Don't know why we're trying to create a Postgres DB with a *.c file when the documentation says it should be a *.d file

https://docs.docker.com/samples/library/postgres/